### PR TITLE
Add Activate Scene action

### DIFF
--- a/HomeAssistantAgent.indigoPlugin/Contents/Server Plugin/Actions.xml
+++ b/HomeAssistantAgent.indigoPlugin/Contents/Server Plugin/Actions.xml
@@ -174,7 +174,19 @@
             </Field>
         </ConfigUI>
     </Action>
-
+	
+    <Action id="send_scene_command">
+        <Name>Activate Scene</Name>
+        <CallbackMethod>send_scene_command</CallbackMethod>
+        <ConfigUI>
+            <Field id="entity_id" type="menu">
+                <Label>Scene Entity:</Label>
+                <List class="self" method="get_entity_list" filter="scene" dynamicReload="true"/>
+                <CallbackMethod>menuChanged</CallbackMethod>
+            </Field>
+        </ConfigUI>
+    </Action>
+	
     <Action id="sep2" />
 
     <Action id="set_text">

--- a/HomeAssistantAgent.indigoPlugin/Contents/Server Plugin/plugin.py
+++ b/HomeAssistantAgent.indigoPlugin/Contents/Server Plugin/plugin.py
@@ -1476,6 +1476,15 @@ class Plugin(indigo.PluginBase):
         else:
             self.logger.warning(f"run_automation_command: missing automation_id")
 
+    def send_scene_command(self, plugin_action, _callerWaitingForResult):
+        self.logger.debug(f"send_scene_command: {plugin_action.props}")
+        if entity_id := plugin_action.props.get("entity_id"):
+            msg_data = {"type": "call_service", 'domain': 'scene', 'service': 'turn_on',
+                                                'service_data': {"entity_id": entity_id}}
+            self.send_ws(msg_data)
+        else:
+            self.logger.warning(f"send_scene_command: missing entity_id")
+                        
     def set_text_command(self, plugin_action, _callerWaitingForResult):
         self.logger.debug(f"set_text_command: {plugin_action.props}")
         if entity_id := plugin_action.props.get("entity_id"):


### PR DESCRIPTION
Adds a new "Activate Scene" action that triggers a Home Assistant scene entity via the scene.turn_on service call.

This addresses the removal of send_generic_command in 2025.0.5 (issue #22). The scene action follows the same pattern as the existing run_automation action.

Changes:
- plugin.py: Added send_scene_command() method
- - Actions.xml: Added send_scene_command action with scene entity dropdown